### PR TITLE
Fix typo in encode command subtext

### DIFF
--- a/.workflow/info.plist
+++ b/.workflow/info.plist
@@ -947,7 +947,7 @@
 				<key>scriptfile</key>
 				<string></string>
 				<key>subtext</key>
-				<string>Encdoe string</string>
+				<string>Encode string</string>
 				<key>title</key>
 				<string>Encode</string>
 				<key>type</key>


### PR DESCRIPTION
Fix typo that shows up in the Alfred window.

<img width="244" alt="Screenshot 2023-10-15 at 10 51 25 pm" src="https://github.com/cage1016/alfred-devtoys/assets/47544496/5ecaa7c3-e1d5-4561-b0b7-74905b0a2ddf">
